### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/styro/security/code-scanning/1](https://github.com/gerlero/styro/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block at the top level of the workflow file (immediately after the `name:` and before the `on:` keys). This applies the permissions to all jobs in the workflow unless jobs have more specific `permissions` blocks. 

For most CI workflows like this—where code is checked out, linted, typed, built, and tested, but there are no jobs requiring write access to the repository—the minimum needed is `contents: read`. If, in the future, a job needs broader permissions (e.g., for release or deployment), that job can still be given its own specific permissions block.

To implement the change:
- Add the lines:
  ```yaml
  permissions:
    contents: read
  ```
  immediately after `name: CI` on line 1 (making it the new line 2), shifting the following lines down.
- No imports, new methods, or other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
