### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   binary:
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/styro/security/code-scanning/2](https://github.com/gerlero/styro/security/code-scanning/2)

The best solution is to explicitly declare a `permissions` block in the workflow to restrict the GitHub token’s permissions as much as possible. Typically, you set it at the top level to apply to all jobs, and then override it per-job if any require greater permissions. In this workflow, most steps (such as checking out code or uploading artifacts) only require `contents: read`, but the step that uploads binaries to a release via `svenstaro/upload-release-action@v2` (which creates or uploads assets to a GitHub Release) needs `contents: write`.

The cleanest fix is to add a `permissions: { contents: read }` block to the root of the workflow and then add a `permissions: { contents: write }` block to the job(s) or steps that require release publishing. In GitHub Actions, `permissions` can only be set at the workflow or job level (not at the step level). Since only the `binary` job contains the release upload, it's sufficient to set `permissions: contents: write` at the `binary` job level (if, in the future, there are multiple jobs, you may set read at the root and write at the job needing it).

However, the minimal compliant fix per the CodeQL recommendation is to add `permissions: contents: write` at the job level for the `binary` job, because the current workflow only has one job and it needs to write to releases. This is also future-proof.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
